### PR TITLE
[Bug] Fix bug not showing radio buttons in dialog when screen rotate

### DIFF
--- a/uizacoresdk/src/main/java/uizacoresdk/util/UZUtil.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/util/UZUtil.java
@@ -242,13 +242,11 @@ public class UZUtil {
             wlp.dimAmount = 0.65f;
             window.setAttributes(wlp);
 
-            int width = 0;
-            int height = 0;
+            int width = ViewGroup.LayoutParams.MATCH_PARENT;
+            int height;
             if (isFullScreen) {
-                width = (int) (context.getResources().getDisplayMetrics().widthPixels * 1.0);
                 height = (int) (context.getResources().getDisplayMetrics().heightPixels * 0.5);
             } else {
-                width = (int) (context.getResources().getDisplayMetrics().widthPixels * 1.0);
                 height = (int) (context.getResources().getDisplayMetrics().heightPixels * 0.3);
             }
             window.setLayout(width, height);

--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZVideo.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZVideo.java
@@ -3522,7 +3522,7 @@ public class UZVideo extends RelativeLayout
             uzPlayerManager.pauseVideo();
             uzPlayerManager.setVolume(0f);
             ViewUtils.visibleViews(rlChromeCast, ibPauseIcon);
-            ViewUtils.goneViews(ibSettingIcon, ibCcIcon, ibBackScreenIcon, ibPlayIcon, ibPauseIcon, ibVolumeIcon);
+//            ViewUtils.goneViews(ibSettingIcon, ibCcIcon, ibBackScreenIcon, ibPlayIcon, ibPauseIcon, ibVolumeIcon);
             //casting player luôn play first với volume not mute
             //UZData.getInstance().getCasty().setVolume(0.99);
 
@@ -3533,7 +3533,7 @@ public class UZVideo extends RelativeLayout
             uzPlayerManager.resumeVideo();
             uzPlayerManager.setVolume(0.99f);
             ViewUtils.goneViews(rlChromeCast, ibPlayIcon);
-            ViewUtils.visibleViews(ibSettingIcon, ibCcIcon, ibBackScreenIcon, ibPauseIcon);
+//            ViewUtils.visibleViews(ibSettingIcon, ibCcIcon, ibBackScreenIcon, ibPauseIcon, ibVolumeIcon);
             //TODO iplm volume mute on/off o cast player
             //khi quay lại exoplayer từ cast player thì mặc định sẽ bật lại âm thanh (dù cast player đang mute hay !mute)
             //uzPlayerManager.setVolume(0.99f);

--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZVideo.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZVideo.java
@@ -2895,6 +2895,7 @@ public class UZVideo extends RelativeLayout
             ((UZPlayerManager) uzPlayerManager).addAdPlayerCallback(new UZAdPlayerCallback() {
                 @Override
                 public void onPlay() {
+                    updateTvDuration();
                     if (videoAdPlayerCallback != null) videoAdPlayerCallback.onPlay();
                 }
 
@@ -2920,11 +2921,13 @@ public class UZVideo extends RelativeLayout
 
                 @Override
                 public void onEnded() {
+                    updateTvDuration();
                     if (videoAdPlayerCallback != null) videoAdPlayerCallback.onEnded();
                 }
 
                 @Override
                 public void onError() {
+                    updateTvDuration();
                     if (videoAdPlayerCallback != null) videoAdPlayerCallback.onError();
                 }
 


### PR DESCRIPTION
**Description:** 
- Radio buttons of Speed, Audio Setting and Video Setting dialog isn't showed when screen change from full screen to small screen.

**Reason:**
- Width of dialog window isn't updated when screen rotated

**Solution:**
- Set the width of dialog window is `MATCH_PARENT`